### PR TITLE
specify mongo image tag

### DIFF
--- a/create-replica-set.sh
+++ b/create-replica-set.sh
@@ -54,7 +54,7 @@ function configMongoContainer {
   createDockerVolume $2
 
   # start container
-  docker run --name $1 -v $2:/data -d mongo --smallfiles
+  docker run --name $1 -v $2:/data -d mongo:3.4.1 --smallfiles
 
   # create the folders necessary for the container
   docker exec -i $1 bash -c 'mkdir /data/keyfile /data/admin'
@@ -88,7 +88,7 @@ function removeAndCreateContainer {
   --env-file $env \
   $serv \
   -p $port \
-  -d mongo --smallfiles \
+  -d mongo:3.4.1 --smallfiles \
   --keyFile /data/keyfile/$keyfile \
   --replSet $rs \
   --storageEngine wiredTiger \


### PR DESCRIPTION
First, thanks for making this tutorial. I was able to complete it with some work. :+1: 

**Problem**
Unless someone manually specifies a correct old dockerhub image tag for mongo that supports the `--smallfiles` flag, the replica set creation and docker machine reset scripts wont work. 

I think this pr is important to help people more smoothly follow the tutorial by requiring them to make less changes specific to their env.

**Commit message**
Dockerhub mongo image pulled by default (image with tag "latest")
does not support the --smallfiles flag. This causes containers to exit
after calling docker run. Specify mongo image mongo:3.4.1 to match
image used in tutorial.